### PR TITLE
Move MapTab wiring and preserve sb.explore

### DIFF
--- a/static/js/MapTab.js
+++ b/static/js/MapTab.js
@@ -3,7 +3,7 @@
 // Wires "Look Around" to a tiny exploration engine and exposes sb.explore for rigging.
 // Logs each step so you can trace flow easily.
 
-import { createExploration } from './exploration.js';
+import { createExploration } from './ui/tabs/exploration.js';
 
 export class MapTab {
   constructor(store, sm) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -23,9 +23,11 @@ sceneManager.switchTo('map');
 
 initTabs(store, sceneManager);
 
-// Dev helpers
-window.sb = {
+// Dev helpers: merge onto any existing helpers so other modules (like MapTab)
+// can attach their own utilities without getting overwritten here.
+window.sb = window.sb || {};
+Object.assign(window.sb, {
   toMap:    () => sceneManager.switchTo('map'),
   toBattle: () => sceneManager.switchTo('battle', { enemy:'Slime' }),
   toTown:   () => sceneManager.switchTo('town', { name:'Oakford' }),
-};
+});

--- a/static/js/ui/tabs.js
+++ b/static/js/ui/tabs.js
@@ -1,6 +1,6 @@
 import { InventoryTab } from './tabs/InventoryTab.js';
 import { CharacterTab } from './tabs/CharacterTab.js';
-import { MapTab } from './tabs/MapTab.js';
+import { MapTab } from '../MapTab.js';
 import { QuestsTab } from './tabs/QuestsTab.js';
 import { SettingsTab } from './tabs/SettingsTab.js';
 


### PR DESCRIPTION
## Summary
- move the wired MapTab implementation into `static/js/MapTab.js` and update tabs to import it
- keep the Look Around button wired to the exploration helper and expose `sb.explore`
- merge dev helpers onto `window.sb` so existing helpers (like explore) persist

## Testing
- python app.py *(fails: ModuleNotFoundError: No module named 'flask')*
- pip install flask *(fails: cannot connect to proxy / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c9609116fc832d9c11128081dcabcd