### PR TITLE
Refine authentication API and align frontend login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Shardbound Prototype Login Flow
+
+## Authentication Overview
+
+The Flask application uses the `auth` blueprint for both the HTML login page and
+JSON APIs consumed by `static/js/play.js` and `static/js/login.js`.
+
+1. Visitors request [`GET /login`](app/templates/login.html) to load the login
+   interface.
+2. The login form calls [`POST /api/login`](app/auth/routes.py) with a JSON body
+   containing `username` and `password`.
+3. On success the server refreshes the session, issues a secure cookie, and
+   returns the authenticated user payload. The frontend then navigates to
+   `/play`.
+4. Subsequent SPA calls hit [`GET /api/me`](app/auth/routes.py) to retrieve the
+   authenticated profile and optional `player` snapshot. Unauthenticated users
+   receive `{ "authenticated": false }` and are redirected to `/login` by the
+   client.
+5. Logout is handled via [`POST /api/logout`](app/auth/routes.py), which clears
+   both the Flask session and any `flask_login` state.
+
+All JSON responses include `credentials: 'include'` and therefore rely on cookie
+sessions instead of bearer tokens. The `auth/service.py` module centralises
+session management, user serialization, and the optional rate-limit hook.
+
+## Running Tests
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest -q
+```
+
+See [`openapi.yaml`](openapi.yaml) for the minimal contract covering the three
+authentication endpoints.

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,24 +1,163 @@
-from flask import Blueprint, render_template, redirect, url_for, request, session
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+from typing import Any, Dict
+
+from flask import (
+    Blueprint,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+
+from app.models import db, User
+from .service import (
+    authenticate,
+    end_session,
+    me_payload,
+    serialize_user,
+    start_session,
+)
+
 try:
-    from flask_login import logout_user, current_user
-except Exception:
-    logout_user = None
+    from flask_login import current_user
+except Exception:  # pragma: no cover - flask_login optional in some envs
     current_user = None
 
 auth_bp = Blueprint("auth", __name__, url_prefix="")
 
-# GET /login — render login form
+
+# ---------------------------------------------------------------------------
+# Page endpoints
+# ---------------------------------------------------------------------------
 @auth_bp.get("/login")
 def login_page():
-    # Render your real login template
-    return render_template("login.html") if "login.html" else ("Login page", 200)
+    if current_user is not None:
+        try:
+            if current_user.is_authenticated:  # type: ignore[attr-defined]
+                return redirect(url_for("game.play"))
+        except Exception:
+            pass
+    return render_template("login.html")
 
-# POST /logout — sign out and go home
+
 @auth_bp.post("/logout")
 def logout():
-    # Clear any session keys you set on login
-    session.pop("user", None)
-    # If using flask_login
-    if logout_user and current_user and getattr(current_user, "is_authenticated", False):
-        logout_user()
-    return redirect(url_for("main.index"))
+    end_session()
+    return redirect(url_for("auth.login_page"))
+
+
+# ---------------------------------------------------------------------------
+# JSON API endpoints (CSRF exempt because they require credentials cookie)
+# ---------------------------------------------------------------------------
+@auth_bp.post("/api/login")
+def api_login():
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return _error_response(HTTPStatus.BAD_REQUEST, "Invalid JSON body.")
+
+    username = (data.get("username") or "").strip()
+    password = (data.get("password") or "").strip()
+
+    if not username or not password:
+        return _error_response(
+            HTTPStatus.BAD_REQUEST,
+            "Username and password are required.",
+            errors={"username": "Required", "password": "Required"},
+        )
+
+    # TODO: hook rate limiting here (e.g. redis-based attempt counter)
+
+    user = authenticate(username, password)
+    if not user:
+        return _error_response(HTTPStatus.UNAUTHORIZED, "Invalid credentials.")
+
+    start_session(user)
+    response = {
+        "ok": True,
+        "user": serialize_user(user),
+        "redirect": url_for("game.play"),
+    }
+    return jsonify(response)
+
+
+@auth_bp.post("/api/logout")
+def api_logout():
+    end_session()
+    return ("", HTTPStatus.NO_CONTENT)
+
+
+@auth_bp.get("/api/me")
+def api_me():
+    payload = me_payload()
+    return jsonify(payload)
+
+
+@auth_bp.post("/api/signup")
+def api_signup():
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return _error_response(HTTPStatus.BAD_REQUEST, "Invalid JSON body.")
+
+    username = (data.get("username") or "").strip()
+    password = (data.get("password") or "").strip()
+    email = (data.get("email") or "").strip() or None
+    first = (data.get("first_name") or "").strip() or None
+    last = (data.get("last_name") or "").strip() or None
+    birthday_raw = (data.get("birthday") or "").strip() or None
+
+    errors: Dict[str, str] = {}
+    if not username:
+        errors["username"] = "Username is required."
+    elif len(username) < 3:
+        errors["username"] = "Username must be at least 3 characters."
+
+    if not password:
+        errors["password"] = "Password is required."
+    elif len(password) < 6:
+        errors["password"] = "Password must be at least 6 characters."
+
+    if email and "@" not in email:
+        errors["email"] = "Invalid email address."
+
+    if errors:
+        return jsonify({"ok": False, "errors": errors}), HTTPStatus.BAD_REQUEST
+
+    if User.query.filter(func.lower(User.username) == username.lower()).first():
+        return jsonify({"ok": False, "errors": {"username": "Taken"}}), HTTPStatus.CONFLICT
+    if email and User.query.filter(func.lower(User.email) == email.lower()).first():
+        return jsonify({"ok": False, "errors": {"email": "In use"}}), HTTPStatus.CONFLICT
+
+    user = User(
+        username=username,
+        email=email,
+        first_name=first,
+        last_name=last,
+        password_hash=User.hash_password(password),
+    )
+    if birthday_raw:
+        try:
+            year, month, day = map(int, birthday_raw.split("-"))
+            user.birthday = date(year, month, day)
+        except Exception:
+            pass
+    db.session.add(user)
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return _error_response(HTTPStatus.CONFLICT, "Account already exists.")
+
+    return jsonify({"ok": True, "message": "Account created. Please log in."}), HTTPStatus.CREATED
+
+
+def _error_response(status: HTTPStatus, message: str, *, errors: Dict[str, Any] | None = None):
+    payload: Dict[str, Any] = {"ok": False, "error": message}
+    if errors:
+        payload["errors"] = errors
+    return jsonify(payload), status

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -1,0 +1,116 @@
+"""Authentication helpers for login/logout/me endpoints."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from flask import session
+from sqlalchemy import func
+
+from app.models import db, User, Player
+
+try:  # flask_login is optional in some deployments
+    from flask_login import current_user as flask_current_user
+    from flask_login import login_user as flask_login_user
+    from flask_login import logout_user as flask_logout_user
+except Exception:  # pragma: no cover - fallback when extension missing
+    flask_current_user = None
+    flask_login_user = None
+    flask_logout_user = None
+
+
+def _normalize_username(raw: str) -> str:
+    return (raw or "").strip()
+
+
+def authenticate(username: str, password: str) -> Optional[User]:
+    """Return the matching user when credentials are valid."""
+    uname = _normalize_username(username)
+    if not uname or not password:
+        return None
+
+    user = (
+        User.query.filter(func.lower(User.username) == uname.lower()).first()
+        if uname
+        else None
+    )
+    if not user:
+        return None
+    return user if user.check_password(password) else None
+
+
+def start_session(user: User) -> None:
+    """Log the user in and harden the session."""
+    session.clear()
+    if flask_login_user:
+        flask_login_user(user)
+    session.permanent = True
+    session["user_id"] = user.id
+    session["username"] = user.username
+    session.modified = True
+
+
+def end_session() -> None:
+    session.clear()
+    if flask_logout_user:
+        try:
+            flask_logout_user()
+        except Exception:
+            # When flask-login isn't initialized we simply ignore it.
+            pass
+
+
+def get_authenticated_user() -> Optional[User]:
+    if flask_current_user is not None:
+        try:
+            if flask_current_user.is_authenticated:
+                return flask_current_user  # type: ignore[return-value]
+        except Exception:
+            pass
+    uid = session.get("user_id")
+    if not uid:
+        return None
+    return User.query.get(uid)
+
+
+def serialize_user(user: User) -> Dict[str, Any]:
+    return {
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+    }
+
+
+def serialize_player(player: Optional[Player]) -> Dict[str, Any]:
+    if not player:
+        return {"has_character": False}
+    return {
+        "has_character": True,
+        "id": player.id,
+        "class_id": player.class_id,
+        "display_name": player.display_name,
+        "onboarding_stage": player.onboarding_stage,
+    }
+
+
+def me_payload() -> Dict[str, Any]:
+    user = get_authenticated_user()
+    if not user:
+        return {"authenticated": False, "user": None}
+
+    player = user.player if hasattr(user, "player") else None
+    payload: Dict[str, Any] = {
+        "authenticated": True,
+        "user": serialize_user(user),
+        "player": serialize_player(player),
+    }
+    return payload
+
+
+def create_user(**kwargs: Any) -> User:
+    """Helper used by tests/seed paths to create a user."""
+    user = User(**kwargs)
+    db.session.add(user)
+    db.session.commit()
+    return user

--- a/app/models.py
+++ b/app/models.py
@@ -3,9 +3,15 @@ from datetime import datetime, date
 import bcrypt
 from flask_sqlalchemy import SQLAlchemy
 
+try:
+    from flask_login import UserMixin
+except Exception:  # pragma: no cover - flask_login optional
+    class UserMixin:  # type: ignore[dead code]
+        pass
+
 db = SQLAlchemy()
 
-class User(db.Model):
+class User(UserMixin, db.Model):
     __tablename__ = "users"
 
     id           = db.Column(db.Integer, primary_key=True)

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -114,7 +114,7 @@
       <input type="text" id="login-username" placeholder="Username" required />
       <input type="password" id="login-password" placeholder="Password" required />
       <button class="submit-btn" type="submit">Enter</button>
-      <div id="login-error" class="error"></div>
+      <div id="login-error" class="error" aria-live="polite"></div>
     </form>
 
     <!-- Signup Form -->
@@ -125,7 +125,7 @@
       <input type="email" id="signup-email" placeholder="Email" required />
       <input type="password" id="signup-password" placeholder="Choose Password" required />
       <button class="submit-btn" type="submit">Create Account</button>
-      <div id="signup-error" class="error"></div>
+      <div id="signup-error" class="error" aria-live="polite"></div>
     </form>
   </div>
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,171 @@
+openapi: 3.0.3
+info:
+  title: Shardbound Auth API
+  version: 0.1.0
+  description: >-
+    Minimal contract for login, logout, and session inspection used by the
+    Shardbound prototype client.
+servers:
+  - url: http://localhost:5000
+    description: Development server
+paths:
+  /api/login:
+    post:
+      summary: Authenticate a user
+      description: >-
+        Validates credentials and issues a session cookie. Responses always use
+        cookies for authentication; CSRF protection for JSON APIs is handled by
+        requiring credentials on every request.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Successful login
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginSuccess'
+        '400':
+          description: Invalid or incomplete payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Incorrect credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too many attempts (reserved for future rate limiting)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - sessionCookieAuth: []
+  /api/logout:
+    post:
+      summary: Terminate the current session
+      responses:
+        '204':
+          description: Logged out successfully
+        '401':
+          description: No active session
+      security:
+        - sessionCookieAuth: []
+  /api/me:
+    get:
+      summary: Return the current authentication state
+      responses:
+        '200':
+          description: Session summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeResponse'
+      security:
+        - sessionCookieAuth: []
+components:
+  securitySchemes:
+    sessionCookieAuth:
+      type: apiKey
+      in: cookie
+      name: session
+      description: Session cookie issued by `/api/login`.
+  schemas:
+    LoginRequest:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+          example: player_one
+        password:
+          type: string
+          format: password
+          example: swordfish
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        email:
+          type: string
+          nullable: true
+          format: email
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+    PlayerSnapshot:
+      type: object
+      properties:
+        has_character:
+          type: boolean
+        id:
+          type: integer
+          nullable: true
+        class_id:
+          type: string
+          nullable: true
+        display_name:
+          type: string
+          nullable: true
+        onboarding_stage:
+          type: string
+          nullable: true
+    LoginSuccess:
+      type: object
+      required:
+        - ok
+        - user
+      properties:
+        ok:
+          type: boolean
+          const: true
+        redirect:
+          type: string
+          description: Preferred location to navigate after login.
+          example: /play
+        user:
+          $ref: '#/components/schemas/User'
+    ErrorResponse:
+      type: object
+      required:
+        - ok
+        - error
+      properties:
+        ok:
+          type: boolean
+        error:
+          type: string
+        errors:
+          type: object
+          additionalProperties:
+            type: string
+    MeResponse:
+      type: object
+      required:
+        - authenticated
+        - user
+      properties:
+        authenticated:
+          type: boolean
+        user:
+          oneOf:
+            - $ref: '#/components/schemas/User'
+            - type: 'null'
+        player:
+          $ref: '#/components/schemas/PlayerSnapshot'

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Generator
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app, db  # type: ignore  # noqa: E402
+from app.models import User, Player  # type: ignore  # noqa: E402
+
+
+@pytest.fixture
+def app() -> Generator:
+    app = create_app({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "WTF_CSRF_ENABLED": False,
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user_id(app) -> int:
+    with app.app_context():
+        user = User(
+            username="testuser",
+            email="test@example.com",
+            password_hash=User.hash_password("secret123"),
+        )
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def test_api_login_success(client, user_id):
+    res = client.post("/api/login", json={"username": "testuser", "password": "secret123"})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["ok"] is True
+    assert data["user"]["username"] == "testuser"
+
+
+def test_api_login_bad_body(client):
+    res = client.post("/api/login", json={})
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["ok"] is False
+
+
+def test_api_login_bad_credentials(client, user_id):
+    res = client.post("/api/login", json={"username": "testuser", "password": "wrong"})
+    assert res.status_code == 401
+    assert res.get_json()["ok"] is False
+
+
+def test_api_me_requires_auth(client):
+    res = client.get("/api/me")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["authenticated"] is False
+    assert data["user"] is None
+
+
+def test_api_me_after_login(client, app, user_id):
+    login = client.post("/api/login", json={"username": "testuser", "password": "secret123"})
+    assert login.status_code == 200
+
+    with app.app_context():
+        player = Player(user_id=user_id, class_id="fighter", gender="male")
+        db.session.add(player)
+        db.session.commit()
+
+    res = client.get("/api/me")
+    data = res.get_json()
+    assert data["authenticated"] is True
+    assert data["user"]["username"] == "testuser"
+    assert data["player"]["has_character"] is True
+    assert data["player"]["class_id"] == "fighter"
+
+
+def test_api_logout_clears_session(client, app, user_id):
+    client.post("/api/login", json={"username": "testuser", "password": "secret123"})
+
+    res = client.post("/api/logout")
+    assert res.status_code in (200, 204)
+
+    me = client.get("/api/me")
+    payload = me.get_json()
+    assert payload["authenticated"] is False


### PR DESCRIPTION
## Summary
- move login, logout, and me endpoints into the auth blueprint with shared helpers and tighter Flask app configuration
- update the login/play frontend logic, template accessibility, and documentation to match the new API contract and publish an OpenAPI spec
- cover the auth workflow with pytest regression tests for happy and failure paths

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd66d0266c832d924e7afcbe76766d